### PR TITLE
Add TTL-based Redis cleanup and graceful shutdown system

### DIFF
--- a/frontend/src/services/socketEventService.ts
+++ b/frontend/src/services/socketEventService.ts
@@ -3,6 +3,7 @@ import { useUIStore } from "@/stores/useUIStore";
 import { useUserStore } from "@/stores/useUserStore";
 import type { Conversation, Message } from "@shared/types";
 import type { QueryClient } from "@tanstack/react-query";
+import toast from "react-hot-toast";
 
 export const setupSocketEvents = (
 	socket: ExtendedSocket,
@@ -149,6 +150,13 @@ export const setupSocketEvents = (
 			}
 		}
 	});
+
+	// heartbeat events
+	socket.on("heartbeat_ack", (data) => {
+		if (!data.success) {
+			toast.error(data.message || "Failed to refresh TTL");
+		}
+	});
 };
 
 const fetchAndAddConversationToCSRLists = async (
@@ -229,9 +237,8 @@ const setInitialConversationWithDelay = () => {
 
 					const searchParams = new URLSearchParams(window.location.search);
 					searchParams.set("conversation_id", firstConversationId);
-					const newUrl = `${
-						window.location.pathname
-					}?${searchParams.toString()}`;
+					const newUrl = `${window.location.pathname
+						}?${searchParams.toString()}`;
 					window.history.replaceState({}, "", newUrl);
 				}
 			}

--- a/frontend/src/services/socketService.ts
+++ b/frontend/src/services/socketService.ts
@@ -45,3 +45,15 @@ export const disconnectSocket = (socket: ExtendedSocket) => {
 export const requestCurrentUserStatus = (socket: ExtendedSocket) => {
     socket.emit("get_current_status");
 };
+
+export const sendHeartbeat = (socket: ExtendedSocket) => {
+    socket.emit("heartbeat");
+};
+
+export const startHeartbeat = (socket: ExtendedSocket) => {
+    return setInterval(() => {
+        if (socket.connected) {
+            sendHeartbeat(socket);
+        }
+    }, 5000); // 5 seconds
+};

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -10,6 +10,7 @@ import { initializeSocketIO } from "./socketio";
 import { createServer } from 'http';
 import { AssignmentEventHandler } from "./services/assignmentEventHandler";
 import workerStatsRouter from "./routers/monitoring";
+import { GracefulShutdownService } from "./services/gracefulShutdown";
 
 // initialize PORT
 const PORT = 5000;
@@ -52,11 +53,9 @@ initializeSocketIO(httpServer);
 const assignmentEventHandler = new AssignmentEventHandler();
 assignmentEventHandler.start();
 
-// Graceful shutdown
-process.on('SIGTERM', async () => {
-    await assignmentEventHandler.stop();
-    process.exit(0);
-});
+// Initialize graceful shutdown service
+const shutdownService = new GracefulShutdownService(httpServer, assignmentEventHandler);
+shutdownService.setupShutdownHandlers();
 
 httpServer.listen(PORT, () => {
     verifyConnections();

--- a/server/src/services/gracefulShutdown.ts
+++ b/server/src/services/gracefulShutdown.ts
@@ -1,0 +1,110 @@
+import type { Server } from "http";
+import type { AssignmentEventHandler } from "./assignmentEventHandler";
+import { redisCleanupService } from "./redisCleanupService";
+import { error } from "console";
+
+export class GracefulShutdownService {
+    private httpServer: Server;
+    private assignmentEventHandler: AssignmentEventHandler;
+    private isShuttingDown: boolean = false;
+
+    constructor(
+        httpServer: Server,
+        assignmentEventHandler: AssignmentEventHandler
+    ) {
+        this.httpServer = httpServer;
+        this.assignmentEventHandler = assignmentEventHandler;
+    }
+
+    /**
+     * setup all shutdown signal handlers
+     */
+
+    public setupShutdownHandlers(): void {
+        // handle all shutdown signals
+        process.on("SIGTERM", () => this.gracefulShutdown("SIGTERM"));
+        process.on("SIGINT", () => this.gracefulShutdown("SIGINT"));
+        process.on("SIGUSR2", () => this.gracefulShutdown("SIGUSR2"));
+
+        // handle uncaught exceptions
+        process.on("uncaughtException", (error) => {
+            console.error("Uncaught exception:", error);
+            this.gracefulShutdown("UNCAUGHT_EXCEPTION");
+        });
+
+        // handle promise rejections if not handled
+        process.on("unhandledRejection", (reason, promise) => {
+            console.error("Unhandled rejection:", reason);
+            this.gracefulShutdown("UNHANDLED_REJECTION");
+        });
+        console.info("Graceful shutdown handlers registered");
+    }
+
+    /**
+     * perform graceful shutdown
+     */
+    private async gracefulShutdown(signal: string): Promise<void> {
+        if (this.isShuttingDown) {
+            console.log(`Shutdown already in progress with signal: ${signal}`);
+            return;
+        }
+
+        this.isShuttingDown = true;
+        console.info(`Received ${signal}, shutting down gracefully...`);
+
+        try {
+            // Step 1: Stop accepting new connections
+            console.info("Stopping new connections...");
+
+            // Step 2: Stop assignment event handler
+            console.info("Stopping assignment event handler...");
+            await this.assignmentEventHandler.stop();
+            console.info("Assignment event handler stopped");
+
+            // Step 3: Redis cleanup
+            console.info("Cleaning up Redis...");
+            await redisCleanupService.gracefulShutdown();
+            console.info("Redis cleanup completed");
+
+            // Step 4: Close HTTP server
+            console.info("Closing HTTP server...");
+            await this.closeHttpServer();
+            console.info("HTTP server closed");
+
+            console.info("Graceful shutdown completed successfully");
+            process.exit(0);
+        } catch (error) {
+            console.error("Error during graceful shutdown:", error);
+            process.exit(1);
+        }
+    }
+
+    /**
+     * close HTTP server with timeout
+     */
+    private closeHttpServer(): Promise<void> {
+        return new Promise((resolve, reject) => {
+            // set timeout for force shutdown after 5 seconds
+            const timeout = setTimeout(() => {
+                console.warn("HTTP server shutdown timed out, force closing...");
+                reject(new Error("HTTP server close timed out"));
+            }, 5000);
+
+            this.httpServer.close((error) => {
+                clearTimeout(timeout);
+                if (error) {
+                    reject(error);
+                } else {
+                    resolve();
+                }
+            });
+        });
+    }
+
+    /**
+     * Get shutdown status
+     */
+    public isShutdownInProgress(): boolean {
+        return this.isShuttingDown;
+    }
+}

--- a/server/src/services/redisCleanupService.ts
+++ b/server/src/services/redisCleanupService.ts
@@ -5,7 +5,7 @@ export class RedisCleanupService {
      * Graceful shutdown cleanup - called when worker/server stops
      */
 
-    async gracefulshutdown(): Promise<void> {
+    async gracefulShutdown(): Promise<void> {
         console.info("Starting graceful shutdown Rediscleanup...");
 
         try {

--- a/server/src/socketio/listeners/user.ts
+++ b/server/src/socketio/listeners/user.ts
@@ -71,6 +71,22 @@ export const registerUserListeners = (socket: ExtendedSocket) => {
             socket.emit("current_status", { status });
         }
     });
+
+    // heartbeat listener
+    socket.on("heartbeat", async () => {
+        if (!socket.data.user) return;
+
+        if (socket.data.user.role === "team_lead") {
+            try {
+                // refresh ttl for team leader
+                await redisUtils.refreshTeamleaderTTL(socket.data.user.id);
+                socket.emit("heartbeat_ack", { timestamp: Date.now(), success: true });
+            } catch (error) {
+                console.error('Heartbeat refresh failed:', error);
+                socket.emit("heartbeat_ack", { timestamp: Date.now(), success: false, message: "Failed to refresh TTL" });
+            }
+        }
+    });
 };
 
 // register user disconnection listeners

--- a/server/src/workers/index.ts
+++ b/server/src/workers/index.ts
@@ -29,7 +29,7 @@ async function startQueueWorker() {
             await new Promise(resolve => setTimeout(resolve, 2000));
 
             // Final cleanup
-            await redisCleanupService.gracefulshutdown();
+            await redisCleanupService.gracefulShutdown();
 
             process.exit(0);
         };

--- a/server/src/workers/queueWorker.ts
+++ b/server/src/workers/queueWorker.ts
@@ -72,7 +72,7 @@ class QueueWorker {
         this.stopPeriodicCleanup(); // Stop periodic cleanup
 
         // 🧹 Graceful cleanup on shutdown
-        redisCleanupService.gracefulshutdown().catch(console.error);
+        redisCleanupService.gracefulShutdown().catch(console.error);
     }
 
     private startHeartbeat(): void {

--- a/shared/socket-types.ts
+++ b/shared/socket-types.ts
@@ -19,6 +19,7 @@ export interface ServerToClientEvents {
     update_conversation: (data: { conversation: Omit<Conversation, "agent">; }) => void;
     remove_from_basket: (data: { conversation_id: string; }) => void;
     current_status: (data: { status: UserStatus; }) => void;
+    heartbeat_ack: (data: { timestamp: number; success: boolean; message?: string; }) => void;
 }
 
 
@@ -30,4 +31,6 @@ export interface ClientToServerEvents {
     leave_conversation: (data: { conversation_id: string; }) => void;
     set_status: (data: { status: "online" | "offline"; }) => void;
     get_current_status: () => void;
+    heartbeat: () => void;
+
 }


### PR DESCRIPTION
## **What This Does**
Implements automatic Redis cleanup with TTL expiration and graceful shutdown handling to prevent stale data and improve system resilience.

## 🔧 **Key Changes**
- **TTL Expiration**: Team leaders auto-expire after 10min, baskets after 2hrs
- **Heartbeat System**: Frontend refreshes TTL every 5min for active team leaders  
- **Graceful Shutdown**: Handles all signals (SIGTERM, SIGINT, SIGUSR2 for nodemon)
- **Auto Cleanup**: Returns assignments to queue on server restart/shutdown
- **Fixed Imports**: Resolved RedisCleanupService export issues

##  **Benefits**
-  **Self-healing**: Stale sessions auto-disappear without manual cleanup
-  **No lost data**: Conversations returned to queue on shutdown
-  **Clean restarts**: Nodemon restarts now clean Redis properly
-  **Better DX**: Clean state after every development restart

##  **Testing**
```bash
# Test TTL
redis-cli TTL "users:online_teamleaders"  # ~600 seconds after login

# Test graceful shutdown  
# Edit any file → Should see "Received SIGUSR2, shutting down gracefully..."
# Ctrl+C → Should see "Redis cleanup completed"
```

## **Files Changed**
- Redis utils: Added TTL to existing functions
- New: `gracefulShutdown.ts` service  
- Frontend: Added heartbeat system
- Server: Added heartbeat handler + shutdown integration